### PR TITLE
VQE BenchmarkAlgorithm and VQEOpt work

### DIFF
--- a/benchmark/tmp_tests/energy.ini
+++ b/benchmark/tmp_tests/energy.ini
@@ -1,0 +1,14 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe-energy
+
+[VQE-Energy]
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/energy_rdm.ini
+++ b/benchmark/tmp_tests/energy_rdm.ini
@@ -1,0 +1,19 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe-energy
+u-p-depol: .025
+cx-p-depol: .3
+
+[Error Mitigation]
+rdm-purification: True
+
+[VQE-Energy]
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/energy_ro.ini
+++ b/benchmark/tmp_tests/energy_ro.ini
@@ -1,0 +1,19 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe-energy
+local-ibm-ro-error: .01,.1
+
+[Error Mitigation]
+readout-error: True
+ro-error-file: /root/.xacc_cache/ro_characterization/local-ibm_NullBackend_ro_error_Sun_Jun_30_15_25_59_2019.json
+
+[VQE-Energy]
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/param_sweep.ini
+++ b/benchmark/tmp_tests/param_sweep.ini
@@ -1,0 +1,16 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: param-sweep
+
+[Sweep]
+upper-bound: pi
+lower-bound: -pi
+num-params: 10
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/param_sweep_rdm.ini
+++ b/benchmark/tmp_tests/param_sweep_rdm.ini
@@ -1,0 +1,21 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: param-sweep
+u-p-depol: .025
+cx-p-depol: .3
+
+[Error Mitigation]
+rdm-purification: True
+
+[Sweep]
+upper-bound: pi
+lower-bound: -pi
+num-params: 10
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/param_sweep_ro.ini
+++ b/benchmark/tmp_tests/param_sweep_ro.ini
@@ -1,0 +1,21 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: param-sweep
+local-ibm-ro-error: .01,.1
+
+[Error Mitigation]
+readout-error: True
+ro-error-file: /root/.xacc_cache/ro_characterization/local-ibm_NullBackend_ro_error_Sun_Jun_30_15_25_59_2019.json
+
+[Sweep]
+upper-bound: pi
+lower-bound: -pi
+num-params: 10
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_bobyqa.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa.ini
@@ -1,0 +1,16 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+
+[VQE]
+optimizer: bobyqa-opt
+options: {'maxfun': 30}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_bobyqa.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa.ini
@@ -5,7 +5,8 @@ algorithm: vqe
 
 [VQE]
 optimizer: bobyqa-opt
-options: {'maxfun': 30}
+options: {'maxfun': 10}
+user-params: {}
 initial-parameters: [0.]
 
 [Ansatz]

--- a/benchmark/tmp_tests/vqe_bobyqa_rdm.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa_rdm.ini
@@ -11,6 +11,7 @@ rdm-purification: True
 [VQE]
 optimizer: bobyqa-opt
 options: {'maxfun': 30}
+user-params: {}
 initial-parameters: [0.]
 
 [Ansatz]

--- a/benchmark/tmp_tests/vqe_bobyqa_rdm.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa_rdm.ini
@@ -1,0 +1,21 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+u-p-depol: .025
+cx-p-depol: .3
+
+[Error Mitigation]
+rdm-purification: True
+
+[VQE]
+optimizer: bobyqa-opt
+options: {'maxfun': 30}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_bobyqa_ro.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa_ro.ini
@@ -11,6 +11,7 @@ ro-error-file: /root/.xacc_cache/ro_characterization/local-ibm_NullBackend_ro_er
 [VQE]
 optimizer: bobyqa-opt
 options: {'maxfun': 30}
+user-params: {}
 initial-parameters: [0.]
 
 [Ansatz]

--- a/benchmark/tmp_tests/vqe_bobyqa_ro.ini
+++ b/benchmark/tmp_tests/vqe_bobyqa_ro.ini
@@ -1,0 +1,21 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+local-ibm-ro-error: .01,.1
+
+[Error Mitigation]
+readout-error: True
+ro-error-file: /root/.xacc_cache/ro_characterization/local-ibm_NullBackend_ro_error_Sun_Jun_30_15_25_59_2019.json
+
+[VQE]
+optimizer: bobyqa-opt
+options: {'maxfun': 30}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_cobyla.ini
+++ b/benchmark/tmp_tests/vqe_cobyla.ini
@@ -1,0 +1,17 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+
+[VQE]
+optimizer: scipy-opt
+method: cobyla
+options: {'maxiter': 30, 'tol': 1e-3, 'disp': True}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_cobyla_rdm.ini
+++ b/benchmark/tmp_tests/vqe_cobyla_rdm.ini
@@ -1,0 +1,22 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+u-p-depol: .025
+cx-p-depol: .3
+
+[Error Mitigation]
+rdm-purification: True
+
+[VQE]
+optimizer: scipy-opt
+method: cobyla
+options: {'maxiter': 30, 'tol': 1e-3, 'disp': True}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/tmp_tests/vqe_cobyla_ro.ini
+++ b/benchmark/tmp_tests/vqe_cobyla_ro.ini
@@ -1,0 +1,22 @@
+[XACC]
+accelerator: local-ibm
+n-shots: 8192
+algorithm: vqe
+local-ibm-ro-error: .01, .1
+
+[Error Mitigation]
+readout-error: True
+ro-error-file: /root/.xacc_cache/ro_characterization/local-ibm_NullBackend_ro_error_Sun_Jun_30_15_25_59_2019.json
+
+[VQE]
+optimizer: scipy-opt
+method: cobyla
+options: {'maxiter': 30, 'tol': 1e-3, 'disp': True}
+initial-parameters: [0.]
+
+[Ansatz]
+name: ucc1
+x-gates: [0,2]
+
+[Molecule]
+hamiltonian-generator: nah_4q_sto3g

--- a/benchmark/vqe.py
+++ b/benchmark/vqe.py
@@ -21,8 +21,7 @@ class VQE(VQEBase):
 
             Parameters:
                 inputParams - a dictionary of input parameters obtained from .ini file
-            Adds options:
-            - 'scipy-[METHOD]': uses scipy.optimize instead of default nelder-mead to optimize the parameters
+
         """
         super().execute(inputParams)
         self.vqe_options_dict['task'] = 'vqe'

--- a/benchmark/vqe.py
+++ b/benchmark/vqe.py
@@ -1,6 +1,4 @@
-from pelix.ipopo.decorators import (ComponentFactory, Property, Requires,
-                                    BindField, UnbindField, Provides, Validate,
-                                    Invalidate, Instantiate)
+from pelix.ipopo.decorators import (ComponentFactory, Property, Instantiate)
 import ast
 import xacc
 import xaccvqe
@@ -8,10 +6,7 @@ from xacc import BenchmarkAlgorithm
 from vqe_base import VQEBase
 
 @ComponentFactory("vqe_benchmark_factory")
-@Provides("benchmark_algorithm")
 @Property("_name", "name", "vqe")
-@Requires("_ansatz_generators", "ansatz_generator", aggregate=True)
-@Requires("_hamiltonian_generators", "hamiltonian_generator", aggregate=True)
 @Instantiate("vqe_benchmark")
 class VQE(VQEBase):
     """
@@ -19,24 +14,6 @@ class VQE(VQEBase):
     """
     def __init__(self):
         super().__init__()
-
-    @BindField('_ansatz_generators')
-    @BindField('_hamiltonian_generators')
-    def bind_dicts(self, field, service, svc_ref):
-        """
-            iPOPO method to bind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
-        """
-        super().bind_dicts(field, service, svc_ref)
-
-    @UnbindField('_ansatz_generators')
-    @UnbindField('_hamiltonian_generators')
-    def unbind_dicts(self, field, service, svc_ref):
-        """
-            iPOPO method to unbind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
-
-            Called when the bundle is invalidated
-        """
-        super().unbind_dicts(field, service, svc_ref)
 
     def execute(self, inputParams):
         """
@@ -49,53 +26,11 @@ class VQE(VQEBase):
         """
         super().execute(inputParams)
         self.vqe_options_dict['task'] = 'vqe'
-        if (inputParams['optimizer'] != 'nelder-mead'):
-            if 'scipy' in inputParams['optimizer']:
-                from scipy.optimize import minimize
-                import numpy as np
-                scipy_opts = {}
-                scipy_opts['method'] = inputParams['optimizer'].replace('scipy-', '')
-                if 'tol' in inputParams:
-                    scipy_opts['tol'] = ast.literal_eval(inputParams['tol'])
-                if 'options' in inputParams:
-                    scipy_opts['options'] = ast.literal_eval(inputParams['options'])
-                else:
-                    scipy_opts['options'] = {'disp': True}
+        if self.optimizer is not None:
+            self.optimizer.optimize(self.op, self.buffer, self.optimizer_options, self.vqe_options_dict)
+        else:
+            result = xaccvqe.execute(self.op, self.buffer, **self.vqe_options_dict)
 
-                energies = []
-                paramStrings = []
-                def energy(p):
-                    paramStr = ','.join([str(x) for x in p])
-                    e = xaccvqe.execute(self.op, self.buffer, **{'task': 'compute-energy',
-                                                           'ansatz': self.ansatz,
-                                                           'vqe-params':paramStr,
-                                                           'accelerator': self.qpu}).energy
-                    if 'rdm-purification' == self.qpu.name():
-                        children = self.buffer.getChildren('parameters',p)
-                        e = children[1].getInformation('purified-energy')
-                        xacc.info('setting energy to purified energy: ' + str(e))
-
-                    energies.append(e)
-                    paramStrings.append(paramStr)
-                    fileName = ".persisted_buffer_%s" % (inputParams['accelerator'])
-                    file = open(fileName+'.ab', 'w')
-                    file.write(str(self.buffer))
-                    file.close()
-                    return e
-                if 'initial-parameters' in inputParams:
-                    init_params = ast.literal_eval(inputParams['initial-parameters'])
-                else:
-                    init_params = np.random.uniform(
-                        low=-np.pi, high=np.pi, size=(self.ansatz.nParameters(),))
-                opt_result = minimize(
-                    energy, init_params, **scipy_opts)
-                self.buffer.addExtraInfo('vqe-energies',energies)
-                self.buffer.addExtraInfo('vqe-parameters',paramStrings)
-                return self.buffer
-            else:
-                xacc.setOption('vqe-backend', inputParams['optimizer'])
-
-        result = xaccvqe.execute(self.op, self.buffer, **self.vqe_options_dict)
         return self.buffer
 
     def analyze(self, buffer, inputParams):

--- a/benchmark/vqe_base.py
+++ b/benchmark/vqe_base.py
@@ -4,7 +4,7 @@ import xaccvqe
 import ast
 import time
 import os
-
+from pelix.ipopo.decorators import (Provides, Requires, BindField, UnbindField)
 #
 #    VQEBase is an abstract class that implements the VQE algorithm using XACC.
 #    VQE and VQEEnergy are iPOPO bundles that inherit from this class to execute the algorithm and analyze results.
@@ -14,11 +14,16 @@ import os
 #        unbind_dicts - Required for using iPOPO service registry
 #        execute - executes the VQE algorithm according to input configurations
 #        analyze - analyzes the AcceleratorBuffer produced from execute()
+@Provides("benchmark_algorithm")
+@Requires("_ansatz_generators", "ansatz_generator", aggregate=True)
+@Requires("_hamiltonian_generators", "hamiltonian_generator", aggregate=True)
+@Requires("_vqe_optimizers", "vqe_optimization", aggregate=True, optional=True)
 class VQEBase(BenchmarkAlgorithm):
 
     def __init__(self):
         self.hamiltonian_generators = {}
         self.ansatz_generators = {}
+        self.vqe_optimizers = {}
         self.vqe_options_dict = {}
         self.n_qubits = 0
         self.buffer = None
@@ -26,6 +31,9 @@ class VQEBase(BenchmarkAlgorithm):
         self.op = None
         self.qpu = None
 
+    @BindField('_vqe_optimizers')
+    @BindField('_ansatz_generators')
+    @BindField('_hamiltonian_generators')
     def bind_dicts(self, field, service, svc_ref):
         """
         This method is intended to be inherited by iPOPO bundle subclasses.
@@ -34,10 +42,16 @@ class VQEBase(BenchmarkAlgorithm):
         if svc_ref.get_property('hamiltonian_generator'):
             generator = svc_ref.get_property('hamiltonian_generator')
             self.hamiltonian_generators[generator] = service
-        elif svc_ref.get_property('ansatz_generator'):
+        if svc_ref.get_property('ansatz_generator'):
             generator = svc_ref.get_property('ansatz_generator')
             self.ansatz_generators[generator] = service
+        if svc_ref.get_property('vqe_optimizer'):
+            optimizer = svc_ref.get_property('vqe_optimizer')
+            self.vqe_optimizers[optimizer] = service
 
+    @UnbindField("_vqe_optimizers")
+    @UnbindField('_ansatz_generators')
+    @UnbindField('_hamiltonian_generators')
     def unbind_dicts(self, field, service, svc_ref):
         """
             This method is intended to be inherited by iPOPO bundle subclasses.
@@ -46,9 +60,12 @@ class VQEBase(BenchmarkAlgorithm):
         if svc_ref.get_property('hamiltonian_generator'):
             generator = svc_ref.get_property('hamiltonian_generator')
             del self.hamiltonian_generators[generator]
-        elif svc_ref.get_property('ansatz_generator'):
+        if svc_ref.get_property('ansatz_generator'):
             generator = svc_ref.get_property('ansatz_generator')
             del self.ansatz_generators[generator]
+        if svc_ref.get_property('vqe_optimizer'):
+            optimizer = svc_ref.get_property('vqe_optimizer')
+            del self.vqe_optimizers[optimizer]
 
     def execute(self, inputParams):
         """
@@ -81,7 +98,6 @@ class VQEBase(BenchmarkAlgorithm):
                 xaccOp, self.ansatz, qubit_map)
         else:
             n_qubits = xaccOp.nQubits()
-
         self.op = xaccOp
         self.n_qubits = n_qubits
         self.buffer = self.qpu.createBuffer('q', n_qubits)
@@ -89,20 +105,38 @@ class VQEBase(BenchmarkAlgorithm):
         self.buffer.addExtraInfo('ansatz-qasm', self.ansatz.toString('q').replace('\\n', '\\\\n'))
         pycompiler = xacc.getCompiler('xacc-py')
         self.buffer.addExtraInfo('ansatz-qasm-py', '\n'.join(pycompiler.translate('q',self.ansatz).split('\n')[1:]))
+        self.optimizer = None
+        self.optimizer_options = {}
+        if 'optimizer' in inputParams:
+            if inputParams['optimizer'] in self.vqe_optimizers:
+                self.optimizer = self.vqe_optimizers[inputParams['optimizer']]
+                if 'method' in inputParams:
+                    self.optimizer_options['method'] = inputParams['method']
+                if 'options' in inputParams:
+                    self.optimizer_options['options'] = ast.literal_eval(inputParams['options'])
+            else:
+                xacc.setOption('vqe-backend', inputParams['optimizer'])
+        else:
+            xacc.info("No classical optimizer specified. Setting to default XACC optimizer.")
 
+        self.buffer.addExtraInfo('accelerator', inputParams['accelerator'])
         if 'n-execs' in inputParams:
             xacc.setOption('sampler-n-execs', inputParams['n-execs'])
+            self.buffer.addExtraInfo('accelerator-decorator', 'improved-sampling')
             self.qpu = xacc.getAcceleratorDecorator('improved-sampling', self.qpu)
 
         if 'restart-from-file' in inputParams:
             xacc.setOption('vqe-restart-file', inputParams['restart-from-file'])
+            self.buffer.addExtraInfo('accelerator-decorator', 'vqe-restart')
             self.qpu = xacc.getAcceleratorDecorator('vqe-restart',self.qpu)
             self.qpu.initialize()
 
         if 'readout-error' in inputParams and inputParams['readout-error']:
+            self.buffer.addExtraInfo('accelerator-decorator', 'readout-error')
             self.qpu = xacc.getAcceleratorDecorator('ro-error',self.qpu)
 
         if 'rdm-purification' in inputParams and inputParams['rdm-purification']:
+            self.buffer.addExtraInfo('accelerator-decorator', 'rdm-purification')
             self.qpu = xacc.getAcceleratorDecorator('rdm-purification', self.qpu)
 
         self.vqe_options_dict = {'accelerator': self.qpu, 'ansatz': self.ansatz}

--- a/benchmark/vqe_base.py
+++ b/benchmark/vqe_base.py
@@ -114,6 +114,8 @@ class VQEBase(BenchmarkAlgorithm):
                     self.optimizer_options['method'] = inputParams['method']
                 if 'options' in inputParams:
                     self.optimizer_options['options'] = ast.literal_eval(inputParams['options'])
+                if 'user-params' in inputParams:
+                    self.optimizer_options['options']['user_params'] = ast.literal_eval(inputParams['user-params'])
             else:
                 xacc.setOption('vqe-backend', inputParams['optimizer'])
         else:

--- a/python/decorators/bobyqa_optimizer.py
+++ b/python/decorators/bobyqa_optimizer.py
@@ -1,5 +1,4 @@
-from pelix.ipopo.decorators import (ComponentFactory, Property, Requires,
-                                    Provides, Instantiate)
+from pelix.ipopo.decorators import (ComponentFactory, Property, Instantiate)
 import xacc
 from xaccvqe import VQEOpt
 import xaccvqe as vqe
@@ -9,8 +8,6 @@ import pybobyqa
 import numpy as np
 
 @ComponentFactory("bobyqa_opt_factory")
-@Provides("vqe_optimization")
-@Property("_name", "name", "bobyqa-opt")
 @Property("_vqe_optimizer", "vqe_optimizer", "bobyqa-opt")
 @Instantiate("bobyqa_opt_instance")
 class BOBYQAOpt(VQEOpt):
@@ -18,23 +15,35 @@ class BOBYQAOpt(VQEOpt):
     def optimize(self, observable, buffer, optimizer_args, execParams):
         super().optimize(observable, buffer, optimizer_args, execParams)
 
-        if 'vqe-params' in self.execParams:
-            init_args = [float(x) for x in self.execParams['vqe-params'].split(',')]
-        else:
-            import random
-            pi = 3.141592653
-            init_args = np.array([random.uniform(-pi, pi) for _ in range(self.execParams['ansatz'].nParameters())])
+        opt_result = pybobyqa.solve(self.energy, self.init_args, **self.opt_args)
 
-        opt_result = pybobyqa.solve(self.energy, init_args, **self.opt_args)
+        # Optimizer adds the results to the buffer automatically
+        buffer.addExtraInfo('vqe-energies', self.energies)
+        buffer.addExtraInfo('vqe-parameters', self.angles)
+        optimal_angles = [float(x) for x in self.angles[self.energies.index(min(self.energies))].split(",")]
+        buffer.addExtraInfo('vqe-angles', optimal_angles)
+        buffer.addExtraInfo('vqe-energy', min(self.energies))
 
-    # For some reason, the Py-BOBYQA module
-    # will not work if using super().energy(params) ( like in ScipyOpt )
-    # so, had to redefine here.
+    # Noticing something very weird if the objective energy function
+    # resides in the super class; looks like it needs to be
+    # redefined everytime (in an optimizer)
     def energy(self, params):
         pStr = ",".join(map(str, params))
         self.execParams['vqe-params'] = pStr
         e = vqe.execute(self.obs, self.buffer, **self.execParams).energy
+
+        if 'rdm-purification' in self.execParams['accelerator'].name():
+            t = self.buffer.getAllUnique('parameters')
+            ind = len(t) - 1
+            children = self.buffer.getChildren('parameters', t[ind])
+            e = children[1].getInformation('purified-energy')
+
         self.angles.append(self.execParams['vqe-params'])
         self.energies.append(e)
+        fileName = ".persisted_buffer_%s" % (self.buffer.getInformation('accelerator')) if self.buffer.hasExtraInfoKey('accelerator') \
+                                                                else ".persisted_buffer_%s" % (self.execParams['accelerator'].name())
+        file = open(fileName+'.ab', 'w')
+        file.write(str(self.buffer))
+        file.close()
         return e
 

--- a/python/decorators/bobyqa_optimizer.py
+++ b/python/decorators/bobyqa_optimizer.py
@@ -14,8 +14,11 @@ class BOBYQAOpt(VQEOpt):
 
     def optimize(self, observable, buffer, optimizer_args, execParams):
         super().optimize(observable, buffer, optimizer_args, execParams)
-
-        opt_result = pybobyqa.solve(self.energy, self.init_args, **self.opt_args)
+        if 'options' in self.opt_args:
+            base_args = self.opt_args['options']
+            opt_result = pybobyqa.solve(self.energy, self.init_args, **base_args)
+        else:
+            opt_result = pybobyqa.solve(self.energy, self.init_args, **self.opt_args)
 
         # Optimizer adds the results to the buffer automatically
         buffer.addExtraInfo('vqe-energies', self.energies)

--- a/python/decorators/scipy_optimizer.py
+++ b/python/decorators/scipy_optimizer.py
@@ -1,5 +1,4 @@
-from pelix.ipopo.decorators import (ComponentFactory, Property, Requires,
-                                    Provides, Instantiate)
+from pelix.ipopo.decorators import (ComponentFactory, Property, Instantiate)
 import xacc
 from xaccvqe import VQEOpt
 import xaccvqe as vqe
@@ -8,8 +7,6 @@ from abc import abstractmethod, ABC
 from scipy.optimize import minimize
 
 @ComponentFactory("scipy_opt_factory")
-@Provides("vqe_optimization")
-@Property("_name", "name", "scipy-opt")
 @Property("_vqe_optimizer", "vqe_optimizer", "scipy-opt")
 @Instantiate("scipy_opt_instance")
 class ScipyOpt(VQEOpt):
@@ -17,17 +14,37 @@ class ScipyOpt(VQEOpt):
     def optimize(self, observable, buffer, optimizer_args, execParams):
         super().optimize(observable, buffer, optimizer_args, execParams)
 
-        if 'vqe-params' in self.execParams:
-            init_args = [float(x) for x in self.execParams['vqe-params'].split(',')]
-        else:
-            import random
-            pi = 3.141592653
-            init_args = [random.uniform(-pi, pi) for _ in range(self.execParams['ansatz'].nParameters())]
+        opt_result = minimize(self.energy, self.init_args, **self.opt_args)
 
-        opt_result = minimize(self.energy, init_args, **self.opt_args)
+        # Optimizer adds the results to the buffer automatically
+        buffer.addExtraInfo('vqe-energies', self.energies)
+        buffer.addExtraInfo('vqe-parameters', self.angles)
+        optimal_angles = [float(x) for x in self.angles[self.energies.index(min(self.energies))].split(",")]
+        buffer.addExtraInfo('vqe-angles', optimal_angles)
+        buffer.addExtraInfo('vqe-energy', min(self.energies))
 
+    # Noticing something very weird if the objective energy function
+    # resides in the super class; looks like it needs to be
+    # redefined everytime (in an optimizer)
     def energy(self, params):
-        super().energy(params)
+        pStr = ",".join(map(str, params))
+        self.execParams['vqe-params'] = pStr
+        e = vqe.execute(self.obs, self.buffer, **self.execParams).energy
+
+        if 'rdm-purification' in self.execParams['accelerator'].name():
+            t = self.buffer.getAllUnique('parameters')
+            ind = len(t) - 1
+            children = self.buffer.getChildren('parameters', t[ind])
+            e = children[1].getInformation('purified-energy')
+
+        self.angles.append(self.execParams['vqe-params'])
+        self.energies.append(e)
+        fileName = ".persisted_buffer_%s" % (self.buffer.getInformation('accelerator')) if self.buffer.hasExtraInfoKey('accelerator') \
+                                                                else ".persisted_buffer_%s" % (self.execParams['accelerator'].name())
+        file = open(fileName+'.ab', 'w')
+        file.write(str(self.buffer))
+        file.close()
+        return e
 
 
 

--- a/python/decorators/wrappedVQE.py
+++ b/python/decorators/wrappedVQE.py
@@ -51,19 +51,12 @@ class WrappedVQEF(xacc.DecoratorFunction):
                 xacc.info("The {} 'vqe_optimization' service is not available.".format(opt_name))
                 exit(1)
             else:
-                optimizer = self.vqe_optimizers[opt_name])
+                optimizer = self.vqe_optimizers[opt_name]
             # get all the options to pass to optimizer
             if 'options' in self.kwargs:
                 optimizer_args = self.kwargs['options']
             # call optimize() method of optimizer
             optimizer.optimize(obs, buffer, optimizer_args, execParams)
-            # add the energies obtained and the angles with which they were obtained
-            # to the AcceleratorBuffer
-            # Also, add the optimal angles to the buffer
-            buffer.addExtraInfo('vqe-energies', optimizer.energies)
-            buffer.addExtraInfo('vqe-parameters', optimizer.angles)
-            vqe_angles = [float(x) for x in optimizer.angles[optimizer.energies.index(min(optimizer.energies))].split(",")]
-            buffer.addExtraInfo('vqe-angles', vqe_angles)
         else:
             vqe.execute(obs, buffer, **execParams)
         return

--- a/python/xaccvqe.py
+++ b/python/xaccvqe.py
@@ -8,7 +8,9 @@ import argparse
 import inspect
 from abc import abstractmethod, ABC
 from xacc import PauliOperator
+from pelix.ipopo.decorators import Provides
 
+@Provides("vqe_optimization")
 class VQEOpt(ABC):
 
     @abstractmethod
@@ -21,18 +23,21 @@ class VQEOpt(ABC):
         self.buffer = buffer
         self.execParams['task'] = 'compute-energy'
 
+        if 'vqe-params' in self.execParams:
+            self.init_args = [float(x) for x in self.execParams['vqe-params'].split(',')]
+        else:
+            import random
+            pi = 3.141592653
+            self.init_args = np.array([random.uniform(-pi, pi) for _ in range(self.execParams['ansatz'].nParameters())])
     # Define the objective function here
     # This is a default objective function using XACC VQE
     # that converges on the computed energy, computing the energy
     # every iteration
     @abstractmethod
     def energy(self, params):
-        pStr = ",".join(map(str, params))
-        self.execParams['vqe-params'] = pStr
-        e = execute(self.obs, self.buffer, **self.execParams).energy
-        self.angles.append(self.execParams['vqe-params'])
-        self.energies.append(e)
-        return e
+        xacc.info("The energy() method is meant to be implemented by VQEOpt subclasses!")
+        exit(1)
+        pass
 
 def QubitOperator2XACC(qubit_op):
     """


### PR DESCRIPTION
Changes to VQE BenchmarkAlgorithm implementations:
**VQE_Base**
- some iPOPO decorators were removed from VQE_Base subclasses (Some iPOPO decorators can be inherited) and added to VQE_base
- VQE_Base now Provides('benchmark_algorithm') and handles Requirements and Binding/Unbinding
- Also, activates the VQEOpt services (if available)
This will check for available Python VQEOpt plugins; if the specified optimizer is not found, it will try to load the optimizer in through XACC core. If no optimizer is specified, it will default to the XACC core CppOpt.

**VQE**
Now uses 'vqe_optimization' service if available
Code cleanup, removal of iPOPO decorators
**VQE-Energy**
Code clean, removal of decorators
**Param-Sweep*
Code cleanup, remove of decorators

**VQEOpt**
Abstract Base Class that resides in xaccvqe.py
Methods: optimize() and energy()
optimize() superclass method initializes everything and is the main driver
energy() is meant to overridden and implemented as the objective function in the VQE

**ScipyOpt**
Provides 'vqe_optimization' service
usable by BenchmarkAlgorithm and DecoratorAlgorithm

**BobyqaOpt**
provides 'vqe_optimization' service
usable by BA and DA

**XACC-VQE/benchmark/tmp_tests**
benchmark tests usings vqe, energy, param sweep, with new optimizers

**Current Issues/Things to consider**
- Scalability using IF/ELSE statements to handle AcceleratorDecorators
(This might require C++ work on VQE to ensure VQE always returns what we want depending on the problem)
- If VQEOpt 'energy()' is defined in the superclass and used by the subclassed Opt implementation, the minimization does not work correctly. Unfortunately, this means the energy() method for ScipyOpt and BobyqaOpt had to be redefined in the Opt class.